### PR TITLE
Use correct item_key configured in the constructor of GRU4Rec

### DIFF
--- a/algorithms/gru4rec/gru4rec.py
+++ b/algorithms/gru4rec/gru4rec.py
@@ -504,7 +504,7 @@ class GRU4Rec:
         data = pd.merge(data, pd.DataFrame({self.item_key:itemids, 'ItemIdx':self.itemidmap[itemids].values}), on=self.item_key, how='inner')
         offset_sessions = self.init_data(data)
         if self.n_sample:
-            pop = data.groupby('ItemId').size()
+            pop = data.groupby(self.item_key).size()
             pop = pop[self.itemidmap.index.values].values**self.sample_alpha
             pop = pop.cumsum() / pop.sum()
             pop[-1] = 1


### PR DESCRIPTION
GRU4Rec constructor allows choosing the item column name as item_key, but in the fit method there was a hardcoded value.