### PR TITLE
yaml.load()  is deprecated and has been replaced with yaml.safe_load()

### DIFF
--- a/run_config.py
+++ b/run_config.py
@@ -54,7 +54,7 @@ def main(conf, out=None):
         print('Loading file')
         send_message('processing config ' + conf)
         stream = open(str(file))
-        c = yaml.load(stream)
+        c = yaml.safe_load(stream)
         stream.close()
 
         try:
@@ -96,7 +96,7 @@ def main(conf, out=None):
                         send_message('processing config ' + list[0])
 
                         stream = open(str(file))
-                        c = yaml.load(stream)
+                        c = yaml.safe_load(stream)
                         stream.close()
 
                         run_file(c)
@@ -133,7 +133,7 @@ def main(conf, out=None):
                     send_message('processing config ' + conf)
 
                     stream = open(str(Path(conf)))
-                    c = yaml.load(stream)
+                    c = yaml.safe_load(stream)
                     stream.close()
 
                     run_file(c)

--- a/run_preprocessing.py
+++ b/run_preprocessing.py
@@ -32,7 +32,7 @@ def main( conf ):
         
         print( 'Loading file' )
         stream = open( str(file) )
-        c = yaml.load(stream)
+        c = yaml.safe_load(stream)
         stream.close()
         print( 'processing config ' + conf )
         


### PR DESCRIPTION
yaml.load is now deprecated and will not work without additional parameters. I have replaced it with yaml.safe_load which is equivalent and does not require additional changes to the code.
https://github.com/bioconda/bioconda-utils/issues/462